### PR TITLE
Make faster algo, add typedarray support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 'use strict';
 
 module.exports = function (arr, size) {
-	if (!Array.isArray(arr)) {
+	if (!Array.isArray(arr) && !ArrayBuffer.isView(arr)) {
 		throw new TypeError('must be an array');
 	}
 
@@ -12,9 +12,12 @@ module.exports = function (arr, size) {
 	size = size || 1;
 
 	var chunk = [];
-
-	while (arr.length > 0) {
-		chunk.push(arr.splice(0, size));
+	for (var i = 0, l = arr.length, group; i < l; i++) {
+		if (!(i % size)) {
+			group = []
+			chunk.push(group)
+		}
+		group.push(arr[i])
 	}
 
 	return chunk;

--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,9 @@ Type: `number`
 
 Length of nested array , default 1
 
+## Related
+
+* [flatten-vertex-data](https://github.com/glo-js/flatten-vertex-data) − flattens array data.
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -29,3 +29,7 @@ it('should throw error when arguments length > 2', function () {
         arrayChunk([1, 2, 3], 2, 3);
     });
 });
+
+it('should support typed arrays', function () {
+    assert.deepEqual(arrayChunk(new Uint8Array([1, 2, 3, 4]), 2), [[1, 2], [3, 4]]);
+});

--- a/test.js
+++ b/test.js
@@ -33,3 +33,7 @@ it('should throw error when arguments length > 2', function () {
 it('should support typed arrays', function () {
     assert.deepEqual(arrayChunk(new Uint8Array([1, 2, 3, 4]), 2), [[1, 2], [3, 4]]);
 });
+
+it('should handle bigger chunk size', function () {
+    assert.deepEqual(arrayChunk([1, 2, 3], 5), [[1,2,3]]);
+})


### PR DESCRIPTION
@hzlmn this makes traversing huge data arrays faster and enables support of TypedArrays. Also fixes #1.
I am going to use that in [regl-scatter2d](https://github.com/dfcreative/regl-scatter2d), hence need the best performance possible.

Please release it as @1.0.0.

Thanks!